### PR TITLE
Fix TwitchPlayer checking wrong location for script

### DIFF
--- a/src/lib/everything/video/TwitchPlayer.ts
+++ b/src/lib/everything/video/TwitchPlayer.ts
@@ -29,7 +29,7 @@ export class TwitchPlayer {
   public static FromOptions(divId: string, options: TwitchPlayerOptions): TwitchPlayer {
     const twitchPlayer = new this();
     try {
-      if ((<any>window).Player && (<any>window).Twitch.Player) {
+      if ((<any>window).Twitch && (<any>window).Twitch.Player) {
         twitchPlayer._player = new (<any>window).Twitch.Player(divId, options);
       } else {
         console.warn('Player was created using the static file, from inside the package. ' +


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
If you attempt to create a new player instance using `TwitchPlayer.FromOptions`, the console logs that the static file is being used even if you have added the external one yourself to the HTML code.

- **What is the new behavior (if this is a feature change)?**
Fixes the above issue and correctly identifies the external script already being loaded.